### PR TITLE
Safari and IOS fix for reply.css

### DIFF
--- a/component/styles/reply.css
+++ b/component/styles/reply.css
@@ -30,12 +30,15 @@
 	transition: all 200ms;
 	text-decoration: none;
 	word-break: normal;
-	animation-duration: 1s;
+	/* animation-duration: 1s; */
 	animation-name: animate-reply;
 	animation-play-state: paused;
 	animation-fill-mode: forwards;
-	opacity: 0;
+	/* opacity: 0; */
 	transform: translate3d(0px, 0px, 0px);
+	animation-delay: -3s;
+-ms-animation-delay: -3;
+-webkit-animation-delay: -3s;
 }
 @keyframes animate-reply {
     from { opacity: 0 }


### PR DESCRIPTION
before these changes, there was a bug for Safari and IOS that you cannot see the reply bubble. 
Simply commenting animation duration and opacity properties solved to problem.
Looking forward to finding a more convenient solution.